### PR TITLE
[PR] Introduce email-proxy/v1/email endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,42 @@
 [![Build Status](https://travis-ci.org/washingtonstateuniversity/WSUWP-Plugin-REST-Email-Proxy.svg?branch=master)](https://travis-ci.org/washingtonstateuniversity/WSUWP-Plugin-REST-Email-Proxy)
 
 A WordPress plugin that provides a REST proxy for sending email from remote WordPress servers.
+
+In a large organization, it's possible that sending email from outside servers can be a painful process. WSUWP REST Email Proxy provides a REST endpoint for sending mail from a server that is already properly configured.
+
+## Endpoint
+
+The endpoint lives at `wp-json/email-proxy/v1/email` and only accepts `POST` requests.
+
+The `POST` request must contain the following data:
+
+```json
+{
+		"send_to": "detination@email.address",
+		"reply_to": "reply_to@email_address",
+		"send_from_name": "From Name",
+		"subject": "Subject of the email",
+		"message": "Contents of the email message",
+		"secret_key": "qwerty12345"
+}
+```
+
+## Secret Key
+
+By default, the plugin will not send an email. Access is managed through the `rest_email_proxy_valid_secret` filter, which defaults to `false`.
+
+This filter also provides the full contents of the `POST` email data so that your code can determine if it's a valid send attempt.
+
+It's suggested that the `secret_key` data is used to control access as this is required in the request.
+
+## Default From Email
+
+The `rest_email_proxy_default_email` filter is provided so that a default from address can be set. If one is not provided, the `reply_to` address is used in its place.
+
+## REST Response
+
+The responses returned by the plugin are very basic.
+
+* If the request does not pass the secret test, a `403` response is returned.
+* If the request does not include the required data, a `400` response is returned.
+* If `wp_mail()` processes, a `200` response is returned. The boolean `success` message will indicate whether the email sent.

--- a/includes/endpoint.php
+++ b/includes/endpoint.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace WSU\RestEmailProxy\Endpoint;
+
+// If this file is called directly, abort.
+if ( ! defined( 'WPINC' ) ) {
+	die;
+}
+
+add_action( 'rest_api_init', 'WSU\RestEmailProxy\Endpoint\register_routes' );
+
+/**
+ * Registers the email-proxy/v1/email REST API endpoint.
+ *
+ * @since 0.0.1
+ */
+function register_routes() {
+	register_rest_route( 'email-proxy/v1', '/email', array(
+		'methods' => 'POST',
+		'callback' => 'WSU\RestEmailProxy\Endpoint\callback',
+	) );
+}
+
+/**
+ * Handles the email-proxy/v1/email endpoint callback and sends
+ * an email when valid information is provided.
+ *
+ * @since 0.0.1
+ *
+ * @param \WP_REST_Request $data
+ * @return \WP_REST_Response
+ */
+function callback( $data ) {
+	$email = $data->get_json_params();
+
+	if ( ! isset( $email['secret_key'] ) || ! apply_filters( 'rest_email_proxy_valid_secret', false, $email ) ) {
+		return new \WP_Rest_Response( array(
+			'error' => 'Invalid secret.',
+		), 403 );
+	}
+
+	$expected = array(
+		'send_to',
+		'send_from',
+		'send_from_name',
+		'subject',
+		'message',
+		'secret_key',
+	);
+	foreach ( $expected as $expect ) {
+		if ( ! isset( $email[ $expect ] ) ) {
+			return new \WP_REST_Response( array(
+				'error' => 'An required parameter was not provided in the request.',
+			), 400 );
+		}
+	}
+
+	$send_to = sanitize_email( $email['send_to'] );
+	$subject = sanitize_text_field( $email['subject'] );
+	$message = wp_kses_post( $email['message'] );
+	$from_email = apply_filters( 'rest_email_proxy_default_email', $email['send_from'] );
+
+	$headers = array(
+		'from: "' . sanitize_text_field( $email['send_from_name'] ) . '" <' . sanitize_email( $from_email ) . '>',
+		'reply-to: ' . sanitize_email( $email['send_from'] ),
+	);
+
+	$result = wp_mail( $send_to, $subject, $message, $headers );
+
+	if ( $result ) {
+		$success = 'Message sent successfully.';
+	} else {
+		$success = 'An error occurred when sending the email.';
+	}
+
+	return new \WP_REST_Response( array(
+		'success' => $success,
+	), 200 );
+}

--- a/includes/endpoint.php
+++ b/includes/endpoint.php
@@ -33,6 +33,7 @@ function register_routes() {
 function callback( $data ) {
 	$email = $data->get_json_params();
 
+	// Do not send email by default. Another plugin should control the secret to success.
 	if ( ! isset( $email['secret_key'] ) || ! apply_filters( 'rest_email_proxy_valid_secret', false, $email ) ) {
 		return new \WP_Rest_Response( array(
 			'error' => 'Invalid secret.',
@@ -58,11 +59,13 @@ function callback( $data ) {
 	$send_to = sanitize_email( $email['send_to'] );
 	$subject = sanitize_text_field( $email['subject'] );
 	$message = wp_kses_post( $email['message'] );
+
+	// Allow for a blanket "from" address that matches the server.
 	$from_email = apply_filters( 'rest_email_proxy_default_email', $email['send_from'] );
 
 	$headers = array(
 		'from: "' . sanitize_text_field( $email['send_from_name'] ) . '" <' . sanitize_email( $from_email ) . '>',
-		'reply-to: ' . sanitize_email( $email['send_from'] ),
+		'reply-to: ' . sanitize_email( $email['send_from'] ), // reply-to is untouched.
 	);
 
 	$result = wp_mail( $send_to, $subject, $message, $headers );

--- a/includes/endpoint.php
+++ b/includes/endpoint.php
@@ -70,13 +70,7 @@ function callback( $data ) {
 
 	$result = wp_mail( $send_to, $subject, $message, $headers );
 
-	if ( $result ) {
-		$success = 'Message sent successfully.';
-	} else {
-		$success = 'An error occurred when sending the email.';
-	}
-
 	return new \WP_REST_Response( array(
-		'success' => $success,
+		'success' => $result,
 	), 200 );
 }

--- a/includes/endpoint.php
+++ b/includes/endpoint.php
@@ -42,7 +42,7 @@ function callback( $data ) {
 
 	$expected = array(
 		'send_to',
-		'send_from',
+		'reply_to',
 		'send_from_name',
 		'subject',
 		'message',
@@ -61,11 +61,11 @@ function callback( $data ) {
 	$message = wp_kses_post( $email['message'] );
 
 	// Allow for a blanket "from" address that matches the server.
-	$from_email = apply_filters( 'rest_email_proxy_default_email', $email['send_from'] );
+	$from_email = apply_filters( 'rest_email_proxy_default_email', $email['reply_to'] );
 
 	$headers = array(
 		'from: "' . sanitize_text_field( $email['send_from_name'] ) . '" <' . sanitize_email( $from_email ) . '>',
-		'reply-to: ' . sanitize_email( $email['send_from'] ), // reply-to is untouched.
+		'reply-to: ' . sanitize_email( $email['reply_to'] ),
 	);
 
 	$result = wp_mail( $send_to, $subject, $message, $headers );

--- a/plugin.php
+++ b/plugin.php
@@ -21,4 +21,6 @@ add_action( 'plugins_loaded', 'WSU\RestEmailProxy\bootstrap' );
  *
  * @since 0.0.1
  */
-function bootstrap() {}
+function bootstrap() {
+	include_once __DIR__ . '/includes/endpoint.php';
+}


### PR DESCRIPTION
This endpoint accepts a properly formatted request containing a secret key and delivers an email using `wp_mail()` based on that request.